### PR TITLE
Remove Duplicate Configuration Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # uiDivStats - WebUI for Diversion statistics
 
 ## v4.0.11
-### Updated on 2025-June-04
+### Updated on 2025-June-07
 
 ## About
 A graphical representation of domain blocking performed by Diversion.


### PR DESCRIPTION
Added/modified code to remove duplicate parameter key names found in the configuration file.
Getting some duplicate key values can cause "bad number" or "arithmetic syntax" errors.