### PR TITLE
Workaround for Entware Binaries using RUNPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # uiDivStats - WebUI for Diversion statistics
 
-## v4.0.15
-### Updated on 2026-Feb-18
+## v4.0.16
+### Updated on 2026-Apr-11
 
 ## About
 A graphical representation of domain blocking performed by Diversion.

--- a/uiDivStats.sh
+++ b/uiDivStats.sh
@@ -13,7 +13,7 @@
 ##       Forked from https://github.com/jackyaz/uiDivStats       ##
 ##                                                               ##
 ###################################################################
-# Last Modified: 2026-Feb-18
+# Last Modified: 2026-Apr-11
 #------------------------------------------------------------------
 
 #################        Shellcheck directives      ###############
@@ -35,8 +35,8 @@
 
 ### Start of script variables ###
 readonly SCRIPT_NAME="uiDivStats"
-readonly SCRIPT_VERSION="v4.0.15"
-readonly SCRIPT_VERSTAG="26021800"
+readonly SCRIPT_VERSION="v4.0.16"
+readonly SCRIPT_VERSTAG="26041103"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
@@ -111,6 +111,9 @@ readonly PassBGRNct="\e[30;102m"
 readonly WarnBYLWct="\e[30;103m"
 
 ### End of output format variables ###
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"


### PR DESCRIPTION
Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method. **RUNPATH** is searched **AFTER** the LD_LIBRARY_PATH definitions, whereas **RPATH** has higher priority than the LD_LIBRARY_PATH environment variable, so it's searched **FIRST**.
